### PR TITLE
[FE] 프로필 이미지 등록 문제 두가지 버그 수정

### DIFF
--- a/client/src/atoms/inputs/ImageInput.js
+++ b/client/src/atoms/inputs/ImageInput.js
@@ -2,12 +2,16 @@ import React, { useRef, useState } from 'react';
 import { ProfileImg, ImgContainer } from '../../pages/contents/ChannelPage';
 import profileGray from '../../assets/images/icons/profile/profileGray.svg';
 import { styled } from 'styled-components';
-import { BodyTextTypo } from '../typographys/Typographys';
+import { BodyTextTypo, SmallTextTypo } from '../typographys/Typographys';
 import { useSelector } from 'react-redux';
 import { NegativeTextButton, PositiveTextButton } from '../buttons/Buttons';
 import { deleteProfileImage, getUploadProfileImgUrlService, getUserInfoService, uploadProfileImage } from '../../services/userInfoService';
 import { useDispatch } from 'react-redux';
 import { setLoginInfo } from '../../redux/createSlice/LoginInfoSlice';
+import tokens from '../../styles/tokens.json';
+import { AlertModal } from '../modal/Modal';
+
+const globalTokens = tokens.global;
 
 const ImageInputContainer = styled.div`
     margin-top: ${props=>props.marginTop?props.marginTop:0}px;
@@ -18,7 +22,11 @@ const ImageInputButtonContainer = styled.div`
     width: 100%;
     display: flex;
     flex-direction: row;
-    justify-content: center;
+    justify-content: start;
+    padding-left: 12px;
+`
+const CautionTextTypo = styled(SmallTextTypo)`
+    color: ${props=>props.isDark?globalTokens.LightRed.value:globalTokens.Negative.value}
 `
 
 export const ImageInput = ({
@@ -29,7 +37,7 @@ export const ImageInput = ({
     const userInfo = useSelector(state=>state.loginInfo.loginInfo);
     const myid = useSelector(state=>state.loginInfo.myid)
     const isDark = useSelector(state=>state.uiSetting.isDark);
-    
+    const [ is이미지등록실패팝업, setIs이미지등록실패팝업 ] = useState(false);
     //새로운 이미지를 선택하면 실행됨
     const onChangeProfileImg = async (e) => {
         const file = e.target.files[0];
@@ -52,11 +60,11 @@ export const ImageInput = ({
                 if(response.status==='success') {
                     dispatch(setLoginInfo({
                         ...userInfo,
-                        imgUrl: response.data.imageUrl
-                    }))
+                        imgUrl: `${response.data.imageUrl}?${new Date().getTime()}`
+                    }));
                 }
             } else {
-
+                setIs이미지등록실패팝업(true);
             }
         } else {
             console.log(response.data);
@@ -78,6 +86,15 @@ export const ImageInput = ({
     }
 
     return (
+        <>
+        {/* 이미지 등록 실패 팝업 */}
+        <AlertModal 
+            isModalOpen={is이미지등록실패팝업}
+            setIsModalOpen={setIs이미지등록실패팝업}
+            isBackdropClickClose={true}
+            content='이미지 등록 실패했습니다.'
+            buttonTitle='확인'
+            handleButtonClick={()=>{setIs이미지등록실패팝업(false)}}/>
         <ImageInputContainer marginTop={marginTop}>
             { label &&
                 <BodyTextTypo isDark={isDark}>{label}</BodyTextTypo>
@@ -106,7 +123,9 @@ export const ImageInput = ({
                         삭제
                 </NegativeTextButton>
             </ImageInputButtonContainer>
+            <CautionTextTypo isDark={isDark}>파일명에 특수문자, 공백을 포함하지 않는 png, jpg, jpeg 파일만 등록 가능합니다. </CautionTextTypo>
         </ImageInputContainer>
+        </>
     );
 };
 

--- a/client/src/atoms/modal/Modal.js
+++ b/client/src/atoms/modal/Modal.js
@@ -113,6 +113,7 @@ export const AlertModal = ({
                     <ModalContent>{content}</ModalContent>
                     <ModalButtonContainer>
                         <ModalPositiveButton 
+                            type='button'
                             onClick={handleButtonClick}>
                                 {buttonTitle}
                         </ModalPositiveButton>

--- a/client/src/redux/Store.js
+++ b/client/src/redux/Store.js
@@ -24,7 +24,7 @@ const reducers = combineReducers({
 const persistConfig = {
   key: "root",
   storage, // 어떤 스토리지 사용할건지 선택, session storage로도 가능함.
-  whitelist: ["loginInfo"], // storage에 저장할 reducer를 선택
+  whitelist: ["loginInfo", "uiSetting"], // storage에 저장할 reducer를 선택
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers); // 기존 reduecr에 persistConfing 내용을 적용시킨 새로운 reducer를 탄생


### PR DESCRIPTION
### 작업한 내용
 - 프로필 이미지 등록 시 캐시 새로고침을 해야지만 이미지가 재랜더링 되는 문제
    - URL이 달라지지 않으면 브라우저가 기존의 이미지를 가져다 쓰기때문에 이런 문제가 생기는것!
    - image URL에 랜덤한 쿼리 파라미터를 줘서 URL을 달라지게 만듦 
 - 프로필 이미지 등록 시 . 이나 공백 문자가 있으면 AWS에서 403 Forbidden을 날림
    - 프로필 등록 밑에 문구 표시, 이미지 등록 실패 시 모달 창 띄우도록 기능 추가